### PR TITLE
Use $PORT variable when starting with Foreman

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-jekyll: bin/jekyll serve --source site
+jekyll: bin/jekyll serve --source site --port $PORT
 sass: bin/sass --watch site/assets/scss:site/assets/css
 js: bin/rerun -x -d "site/assets/src-js" make build-js


### PR DESCRIPTION
Foreman passes '5000' as a default value for $PORT. This makes the
default development environment match the port in the README.